### PR TITLE
feat: Add iterator and range constraints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
         "memory_resource": "cpp",
         "numeric": "cpp",
         "random": "cpp",
+        "ranges": "cpp",
         "ratio": "cpp",
         "string_view": "cpp",
         "system_error": "cpp",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ int main()
 
 # Interfaces
 
-### `template<typename ForwardIterator>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardIterator first, ForwardIterator last)`
+### `template<std::forward_iterator ForwardIterator>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardIterator first, ForwardIterator last)`
 
 #### Preconditions
 
@@ -54,6 +54,6 @@ Calculate the replacement number, which is equal to the deficiency number (a.k.a
 |-------|-------|-------|-------|-------|-----------|-----------|---------|
 | Tile  | 🀀 (E) | 🀁 (S) | 🀂 (W) | 🀃 (N) | 🀆 (White) | 🀅 (Green) | 🀄 (Red) |
 
-### `template<typename ForwardRange>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardRange const &r)`
+### `template<std::ranges::forward_range ForwardRange>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardRange const &r)`
 
 Call `Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r))`.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Calculate the replacement number, which is equal to the deficiency number (a.k.a
 
 ### `template<typename R>`<br/>`requires std::ranges::random_access_range<R const>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
 
-Call `Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r))`.
+Call `Nyanten::calculateReplacementNumber(std::ranges::cbegin(r), std::ranges::cend(r))`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,6 @@ Calculate the replacement number, which is equal to the deficiency number (a.k.a
 |-------|-------|-------|-------|-------|-----------|-----------|---------|
 | Tile  | 🀀 (E) | 🀁 (S) | 🀂 (W) | 🀃 (N) | 🀆 (White) | 🀅 (Green) | 🀄 (Red) |
 
-### `template<std::ranges::random_access_range R>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
+### `template<typename R>`<br/>`requires std::ranges::random_access_range<R const>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
 
 Call `Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r))`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ int main()
 
 # Interfaces
 
-### `template<std::forward_iterator I, std::sentinel_for<I> S>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(I first, S last)`
+### `template<std::random_access_iterator I, std::sentinel_for<I> S>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(I first, S last)`
 
 #### Preconditions
 
@@ -54,6 +54,6 @@ Calculate the replacement number, which is equal to the deficiency number (a.k.a
 |-------|-------|-------|-------|-------|-----------|-----------|---------|
 | Tile  | 🀀 (E) | 🀁 (S) | 🀂 (W) | 🀃 (N) | 🀆 (White) | 🀅 (Green) | 🀄 (Red) |
 
-### `template<std::ranges::forward_range R>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
+### `template<std::ranges::random_access_range R>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
 
 Call `Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r))`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ int main()
 
 # Interfaces
 
-### `template<std::forward_iterator I>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(I first, I last)`
+### `template<std::forward_iterator I, std::sentinel_for<I> S>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(I first, S last)`
 
 #### Preconditions
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ int main()
 
 # Interfaces
 
-### `template<std::forward_iterator ForwardIterator>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardIterator first, ForwardIterator last)`
+### `template<std::forward_iterator I>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(I first, I last)`
 
 #### Preconditions
 
@@ -54,6 +54,6 @@ Calculate the replacement number, which is equal to the deficiency number (a.k.a
 |-------|-------|-------|-------|-------|-----------|-----------|---------|
 | Tile  | 🀀 (E) | 🀁 (S) | 🀂 (W) | 🀃 (N) | 🀆 (White) | 🀅 (Green) | 🀄 (Red) |
 
-### `template<std::ranges::forward_range ForwardRange>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(ForwardRange const &r)`
+### `template<std::ranges::forward_range R>`<br/>`std::uint_fast8_t Nyanten::calculateReplacementNumber(R const &r)`
 
 Call `Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r))`.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ int main()
 
 #### Preconditions
 
-- `std::distance(first, last) == 34`
+- `[first, last)` is a valid range containing exactly 34 elements.
 - For every `iter` in the range `[first, last)`, `0 <= *iter` and `*iter <= 4`
 - The sum of the numbers in the range `[first, last)` is less or equal to 14.
 - The sum of the numbers in the range `[first, last)` is congruent to 1 or 2 modulo 3.

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -10,12 +10,13 @@
 #include <nyanten/standard/replacement_number.hpp>
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <cstdint>
 
 
 namespace Nyanten{
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, ForwardIterator last)
 {
   std::uint_fast8_t const n = [&]() {
@@ -50,7 +51,7 @@ std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, ForwardItera
   return std::min({r0, r1, r2});
 }
 
-template<typename ForwardRange>
+template<std::ranges::forward_range ForwardRange>
 std::uint_fast8_t calculateReplacementNumber(ForwardRange const &r)
 {
   return Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r));

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -16,7 +16,7 @@
 
 namespace Nyanten{
 
-template<std::forward_iterator I, std::sentinel_for<I> S>
+template<std::random_access_iterator I, std::sentinel_for<I> S>
 std::uint_fast8_t calculateReplacementNumber(I first, S last)
 {
   std::uint_fast8_t const n = [&]() {
@@ -51,7 +51,7 @@ std::uint_fast8_t calculateReplacementNumber(I first, S last)
   return std::min({r0, r1, r2});
 }
 
-template<std::ranges::forward_range R>
+template<std::ranges::random_access_range R>
 std::uint_fast8_t calculateReplacementNumber(R const &r)
 {
   return Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r));

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -16,8 +16,8 @@
 
 namespace Nyanten{
 
-template<std::forward_iterator I>
-std::uint_fast8_t calculateReplacementNumber(I first, I last)
+template<std::forward_iterator I, std::sentinel_for<I> S>
+std::uint_fast8_t calculateReplacementNumber(I first, S last)
 {
   std::uint_fast8_t const n = [&]() {
     std::uint_fast8_t i = 0u;

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <iterator>
 #include <ranges>
+#include <stdexcept>
 #include <cstdint>
 
 

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -16,13 +16,13 @@
 
 namespace Nyanten{
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, ForwardIterator last)
+template<std::forward_iterator I>
+std::uint_fast8_t calculateReplacementNumber(I first, I last)
 {
   std::uint_fast8_t const n = [&]() {
     std::uint_fast8_t i = 0u;
     std::uint_fast8_t n = 0u;
-    for (ForwardIterator iter = first; iter != last; ++iter) {
+    for (I iter = first; iter != last; ++iter) {
       if (*iter < 0) {
         throw std::invalid_argument("All tile counts must be non-negative.");
       }
@@ -51,8 +51,8 @@ std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, ForwardItera
   return std::min({r0, r1, r2});
 }
 
-template<std::ranges::forward_range ForwardRange>
-std::uint_fast8_t calculateReplacementNumber(ForwardRange const &r)
+template<std::ranges::forward_range R>
+std::uint_fast8_t calculateReplacementNumber(R const &r)
 {
   return Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r));
 }

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -56,7 +56,7 @@ template<typename R>
   requires std::ranges::random_access_range<R const>
 std::uint_fast8_t calculateReplacementNumber(R const &r)
 {
-  return Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r));
+  return Nyanten::calculateReplacementNumber(std::ranges::cbegin(r), std::ranges::cend(r));
 }
 
 } // namespace Nyanten

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -53,7 +53,7 @@ std::uint_fast8_t calculateReplacementNumber(I first, S last)
 }
 
 template<typename R>
-  requires std::ranges::random_access_range<R const>
+requires std::ranges::random_access_range<R const>
 std::uint_fast8_t calculateReplacementNumber(R const &r)
 {
   return Nyanten::calculateReplacementNumber(std::ranges::cbegin(r), std::ranges::cend(r));

--- a/nyanten/replacement_number.hpp
+++ b/nyanten/replacement_number.hpp
@@ -52,7 +52,8 @@ std::uint_fast8_t calculateReplacementNumber(I first, S last)
   return std::min({r0, r1, r2});
 }
 
-template<std::ranges::random_access_range R>
+template<typename R>
+  requires std::ranges::random_access_range<R const>
 std::uint_fast8_t calculateReplacementNumber(R const &r)
 {
   return Nyanten::calculateReplacementNumber(std::cbegin(r), std::cend(r));

--- a/nyanten/seven_pairs/replacement_number.hpp
+++ b/nyanten/seven_pairs/replacement_number.hpp
@@ -5,12 +5,13 @@
 #if !defined(NYANTEN_SEVEN_PAIRS_REPLACEMENT_NUMBER_HPP_INCLUDE_GUARD)
 #define NYANTEN_SEVEN_PAIRS_REPLACEMENT_NUMBER_HPP_INCLUDE_GUARD
 
+#include <iterator>
 #include <limits>
 #include <cstdint>
 
 namespace Nyanten::SevenPairs_{
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast8_t calculateReplacementNumber(
   ForwardIterator first, ForwardIterator last, std::uint_fast8_t const n)
 {

--- a/nyanten/seven_pairs/replacement_number.hpp
+++ b/nyanten/seven_pairs/replacement_number.hpp
@@ -11,8 +11,8 @@
 
 namespace Nyanten::SevenPairs_{
 
-template<std::forward_iterator I>
-std::uint_fast8_t calculateReplacementNumber(I first, I last, std::uint_fast8_t const n)
+template<std::forward_iterator I, std::sentinel_for<I> S>
+std::uint_fast8_t calculateReplacementNumber(I first, S last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14u) {
     return std::numeric_limits<std::uint_fast8_t>::max();

--- a/nyanten/seven_pairs/replacement_number.hpp
+++ b/nyanten/seven_pairs/replacement_number.hpp
@@ -11,7 +11,7 @@
 
 namespace Nyanten::SevenPairs_{
 
-template<std::forward_iterator I, std::sentinel_for<I> S>
+template<std::input_iterator I, std::sentinel_for<I> S>
 std::uint_fast8_t calculateReplacementNumber(I first, S last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14u) {

--- a/nyanten/seven_pairs/replacement_number.hpp
+++ b/nyanten/seven_pairs/replacement_number.hpp
@@ -11,9 +11,8 @@
 
 namespace Nyanten::SevenPairs_{
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast8_t calculateReplacementNumber(
-  ForwardIterator first, ForwardIterator last, std::uint_fast8_t const n)
+template<std::forward_iterator I>
+std::uint_fast8_t calculateReplacementNumber(I first, I last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14u) {
     return std::numeric_limits<std::uint_fast8_t>::max();

--- a/nyanten/standard/hash.hpp
+++ b/nyanten/standard/hash.hpp
@@ -7,13 +7,14 @@
 
 #include <nyanten/standard/zipai_table.hpp>
 #include <nyanten/standard/shupai_table.hpp>
+#include <iterator>
 #include <cstdint>
 #include <cassert>
 
 
 namespace Nyanten::Standard_{
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast32_t hashShupai(ForwardIterator first, ForwardIterator last)
 {
   std::uint_fast32_t h = 0u;
@@ -35,7 +36,7 @@ std::uint_fast32_t hashShupai(ForwardIterator first, ForwardIterator last)
   return h;
 }
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast32_t hashZipai(ForwardIterator first, ForwardIterator last)
 {
   std::uint_fast32_t h = 0u;

--- a/nyanten/standard/hash.hpp
+++ b/nyanten/standard/hash.hpp
@@ -14,8 +14,8 @@
 
 namespace Nyanten::Standard_{
 
-template<std::forward_iterator I>
-std::uint_fast32_t hashShupai(I first, I last)
+template<std::forward_iterator I, std::sentinel_for<I> S>
+std::uint_fast32_t hashShupai(I first, S last)
 {
   std::uint_fast32_t h = 0u;
   {
@@ -36,8 +36,8 @@ std::uint_fast32_t hashShupai(I first, I last)
   return h;
 }
 
-template<std::forward_iterator I>
-std::uint_fast32_t hashZipai(I first, I last)
+template<std::forward_iterator I, std::sentinel_for<I> S>
+std::uint_fast32_t hashZipai(I first, S last)
 {
   std::uint_fast32_t h = 0u;
   {

--- a/nyanten/standard/hash.hpp
+++ b/nyanten/standard/hash.hpp
@@ -14,8 +14,8 @@
 
 namespace Nyanten::Standard_{
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast32_t hashShupai(ForwardIterator first, ForwardIterator last)
+template<std::forward_iterator I>
+std::uint_fast32_t hashShupai(I first, I last)
 {
   std::uint_fast32_t h = 0u;
   {
@@ -36,8 +36,8 @@ std::uint_fast32_t hashShupai(ForwardIterator first, ForwardIterator last)
   return h;
 }
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast32_t hashZipai(ForwardIterator first, ForwardIterator last)
+template<std::forward_iterator I>
+std::uint_fast32_t hashZipai(I first, I last)
 {
   std::uint_fast32_t h = 0u;
   {

--- a/nyanten/standard/hash.hpp
+++ b/nyanten/standard/hash.hpp
@@ -14,7 +14,7 @@
 
 namespace Nyanten::Standard_{
 
-template<std::forward_iterator I, std::sentinel_for<I> S>
+template<std::input_iterator I, std::sentinel_for<I> S>
 std::uint_fast32_t hashShupai(I first, S last)
 {
   std::uint_fast32_t h = 0u;
@@ -36,7 +36,7 @@ std::uint_fast32_t hashShupai(I first, S last)
   return h;
 }
 
-template<std::forward_iterator I, std::sentinel_for<I> S>
+template<std::input_iterator I, std::sentinel_for<I> S>
 std::uint_fast32_t hashZipai(I first, S last)
 {
   std::uint_fast32_t h = 0u;

--- a/nyanten/standard/replacement_number.hpp
+++ b/nyanten/standard/replacement_number.hpp
@@ -10,6 +10,7 @@
 #include <nyanten/standard/core.hpp>
 #include <algorithm>
 #include <array>
+#include <iterator>
 #include <cstdint>
 
 
@@ -21,7 +22,7 @@ using Nyanten::Standard_::Key2;
 using Nyanten::Standard_::shupai_keys;
 using Nyanten::Standard_::zipai_keys;
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, std::uint_fast8_t const n)
 {
   std::uint_fast8_t const m = n / 3u;

--- a/nyanten/standard/replacement_number.hpp
+++ b/nyanten/standard/replacement_number.hpp
@@ -22,7 +22,7 @@ using Nyanten::Standard_::Key2;
 using Nyanten::Standard_::shupai_keys;
 using Nyanten::Standard_::zipai_keys;
 
-template<std::forward_iterator I>
+template<std::random_access_iterator I>
 std::uint_fast8_t calculateReplacementNumber(I first, std::uint_fast8_t const n)
 {
   std::uint_fast8_t const m = n / 3u;

--- a/nyanten/standard/replacement_number.hpp
+++ b/nyanten/standard/replacement_number.hpp
@@ -8,8 +8,6 @@
 #include <nyanten/standard/keys.hpp>
 #include <nyanten/standard/hash.hpp>
 #include <nyanten/standard/core.hpp>
-#include <algorithm>
-#include <array>
 #include <iterator>
 #include <cstdint>
 

--- a/nyanten/standard/replacement_number.hpp
+++ b/nyanten/standard/replacement_number.hpp
@@ -22,8 +22,8 @@ using Nyanten::Standard_::Key2;
 using Nyanten::Standard_::shupai_keys;
 using Nyanten::Standard_::zipai_keys;
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast8_t calculateReplacementNumber(ForwardIterator first, std::uint_fast8_t const n)
+template<std::forward_iterator I>
+std::uint_fast8_t calculateReplacementNumber(I first, std::uint_fast8_t const n)
 {
   std::uint_fast8_t const m = n / 3u;
 

--- a/nyanten/thirteen_orphans/replacement_number.hpp
+++ b/nyanten/thirteen_orphans/replacement_number.hpp
@@ -12,7 +12,7 @@
 
 namespace Nyanten::ThirteenOrphans_{
 
-template<typename ForwardIterator>
+template<std::forward_iterator ForwardIterator>
 std::uint_fast8_t calculateReplacementNumber(
   ForwardIterator first, ForwardIterator last, std::uint_fast8_t const n)
 {

--- a/nyanten/thirteen_orphans/replacement_number.hpp
+++ b/nyanten/thirteen_orphans/replacement_number.hpp
@@ -12,8 +12,8 @@
 
 namespace Nyanten::ThirteenOrphans_{
 
-template<std::forward_iterator I>
-std::uint_fast8_t calculateReplacementNumber(I first, I last, std::uint_fast8_t const n)
+template<std::forward_iterator I, std::sentinel_for<I> S>
+std::uint_fast8_t calculateReplacementNumber(I first, S last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14) {
     return std::numeric_limits<std::uint_fast8_t>::max();

--- a/nyanten/thirteen_orphans/replacement_number.hpp
+++ b/nyanten/thirteen_orphans/replacement_number.hpp
@@ -12,9 +12,8 @@
 
 namespace Nyanten::ThirteenOrphans_{
 
-template<std::forward_iterator ForwardIterator>
-std::uint_fast8_t calculateReplacementNumber(
-  ForwardIterator first, ForwardIterator last, std::uint_fast8_t const n)
+template<std::forward_iterator I>
+std::uint_fast8_t calculateReplacementNumber(I first, I last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14) {
     return std::numeric_limits<std::uint_fast8_t>::max();

--- a/nyanten/thirteen_orphans/replacement_number.hpp
+++ b/nyanten/thirteen_orphans/replacement_number.hpp
@@ -12,7 +12,7 @@
 
 namespace Nyanten::ThirteenOrphans_{
 
-template<std::forward_iterator I, std::sentinel_for<I> S>
+template<std::input_iterator I, std::sentinel_for<I> S>
 std::uint_fast8_t calculateReplacementNumber(I first, S last, std::uint_fast8_t const n)
 {
   if (n != 13u && n != 14) {


### PR DESCRIPTION
## Summary

This PR replaces the unconstrained iterator and range template parameters with C++20 concepts matching their current implementations.

It also corrects the relevant standard library header dependencies.

## Changes

* Constrain the public iterator overload with `std::random_access_iterator` and `std::sentinel_for`.
* Constrain the public range overload with `std::ranges::random_access_range<R const>`.
* Use `std::ranges::cbegin` and `std::ranges::cend` in the range overload.
* Constrain the standard-form calculation with `std::random_access_iterator`.
* Constrain the seven-pairs and thirteen-orphans calculations with `std::input_iterator` and `std::sentinel_for`.
* Constrain `hashShupai` and `hashZipai` with `std::input_iterator` and `std::sentinel_for`.
* Add the missing `<stdexcept>` include.
* Remove unused `<algorithm>` and `<array>` includes from the standard-form implementation header.

## Rationale

The standard-form implementation currently uses random-access operations such as:

```cpp
first + 9u
first + 18u
first + 27u
first + 34u
```

Therefore, the public iterator overload and the standard-form calculation require random-access iterators under the current implementation.

The seven-pairs, thirteen-orphans, and hash calculations only perform a single traversal, so `std::input_iterator` is sufficient for those functions.

The range overload accepts `R const&`, so its constraint is applied to `R const`. It uses the ranges access CPOs consistently:

```cpp
template<typename R>
requires std::ranges::random_access_range<R const>
std::uint_fast8_t calculateReplacementNumber(R const& r)
{
  return Nyanten::calculateReplacementNumber(std::ranges::cbegin(r), std::ranges::cend(r));
}
```

The separate sentinel parameters avoid requiring the iterator and end sentinel to have the same type.

## Compatibility

Although the previous public template parameter was named `ForwardIterator`, the standard-form implementation already required random-access operations. This PR makes that existing requirement explicit.

## Possible alternative

If the original forward-iterator contract is preferred, the standard-form boundaries can instead be constructed with `std::next`:

```cpp
const auto pinzu = std::next(first, 9);
const auto souzu = std::next(pinzu, 9);
const auto honors = std::next(souzu, 9);
const auto last = std::next(honors, 7);

const auto manzu_hash = hashShupai(first, pinzu);
const auto pinzu_hash = hashShupai(pinzu, souzu);
const auto souzu_hash = hashShupai(souzu, honors);
const auto honors_hash = hashZipai(honors, last);
```

This would allow the public API and standard-form calculation to use `std::forward_iterator`. I left this implementation change out of the PR to preserve the current code and performance characteristics.
